### PR TITLE
add sensor's description to sensorLabels

### DIFF
--- a/collector/sensor.go
+++ b/collector/sensor.go
@@ -12,7 +12,7 @@ import (
 var (
 	sensorSubsystem = "sensor"
 
-	sensorLabels = []string{"sensor"}
+	sensorLabels = []string{"sensor", "description"}
 
 	sensorDesc = map[string]*prometheus.Desc{
 		"state":       colPromDesc(sensorSubsystem, "state", "State of Sensor (0 = Bad, 1 = Ok, 2 = Absent).", sensorLabels),
@@ -102,7 +102,7 @@ func processSensorStats(ch chan<- prometheus.Metric, jsonSensorSum []byte) error
 	}
 
 	for _, sensor := range jsonSensors {
-		labels := []string{strings.ToLower(sensor.Name)}
+		labels := []string{strings.ToLower(sensor.Name), strings.ToLower(sensor.Description)}
 
 		if strings.ToLower(sensor.State) == "ok" {
 			newGauge(ch, sensorDesc["state"], 1.0, labels...)
@@ -129,6 +129,7 @@ func processSensorStats(ch chan<- prometheus.Metric, jsonSensorSum []byte) error
 
 type sensorData []struct {
 	Name  string  `json:"name"`
+	Description string `json:"description"`
 	State string  `json:"state"`
 	Input float64 `json:"input,omitempty"`
 	Type  string  `json:"type"`


### PR DESCRIPTION
Cumulus Linux's `smonctl -j`  output has "description" key, and it is easier to identify than the "name" key.

```
$ smonctl -j
...<snip>
        "crit_action_path": null,
        "state": "OK",
        "msg": null,
        "prev_state": "OK",
        "type": "temp",
        "description": "ILET_AF_temp",
        "thres_action_path": null,
        "max": 80,
        "start_time": 1586153308,
        "input": 27.0,
        "log_time": 1586153308,
        "name": "Temp22",
        "min": 5,
        "driver_path": "/sys/class/misc/vhwmon/bmc:temp"
...<snip>
```

so, add "description" to sensorLabels.



metrics example is below.

pre

```
cumulus_sensor_temperature_celsius{sensor="temp22"} 27
cumulus_sensor_temperature_celsius{sensor="temp23"} 30
```

pst  

```
cumulus_sensor_temperature_celsius{description="ilet_af_temp",sensor="temp22"} 26
cumulus_sensor_temperature_celsius{description="cpu_temp",sensor="temp23"} 30
```