### PR TITLE
parse resource json with dynamic key

### DIFF
--- a/collector/resource.go
+++ b/collector/resource.go
@@ -70,7 +70,7 @@ func processResourceStats(ch chan<- prometheus.Metric, jsonResourceSum []byte) e
 
 	for _, v := range dataMap {
 	        newGauge(ch, resourceDesc["max"], v.Max, strings.ToLower(v.Name))
-	        newGauge(ch, resourceDesc["used"], v.Max, strings.ToLower(v.Name))
+	        newGauge(ch, resourceDesc["used"], v.Count, strings.ToLower(v.Name))
 	}
 
 	return nil

--- a/collector/resource.go
+++ b/collector/resource.go
@@ -63,137 +63,20 @@ func getResourceStats() ([]byte, error) {
 }
 
 func processResourceStats(ch chan<- prometheus.Metric, jsonResourceSum []byte) error {
-	var jsonResources resourceData
-
-	if err := json.Unmarshal(jsonResourceSum, &jsonResources); err != nil {
+	dataMap := map[string]*resourceEntry{}
+	if err:= json.Unmarshal(jsonResourceSum, &dataMap); err != nil {
 		return fmt.Errorf("cannot unmarshal resource json: %s", err)
 	}
 
-	newGauge(ch, resourceDesc["max"], jsonResources.ACLL4PortRangeCheckers.Max, strings.ToLower(jsonResources.ACLL4PortRangeCheckers.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.ACLL4PortRangeCheckers.Count, strings.ToLower(jsonResources.ACLL4PortRangeCheckers.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.ECMPNhEntry.Max, strings.ToLower(jsonResources.ECMPNhEntry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.ECMPNhEntry.Count, strings.ToLower(jsonResources.ECMPNhEntry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.EgACLCounter.Max, strings.ToLower(jsonResources.EgACLCounter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.EgACLCounter.Count, strings.ToLower(jsonResources.EgACLCounter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.EgACLEntry.Max, strings.ToLower(jsonResources.EgACLEntry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.EgACLEntry.Count, strings.ToLower(jsonResources.EgACLEntry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.EgACLMeter.Max, strings.ToLower(jsonResources.EgACLMeter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.EgACLMeter.Count, strings.ToLower(jsonResources.EgACLMeter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.EgACLSlice.Max, strings.ToLower(jsonResources.EgACLSlice.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.EgACLSlice.Count, strings.ToLower(jsonResources.EgACLSlice.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.EgACLV4MacFilter.Max, strings.ToLower(jsonResources.EgACLV4MacFilter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.EgACLV4MacFilter.Count, strings.ToLower(jsonResources.EgACLV4MacFilter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.EgACLV6Filter.Max, strings.ToLower(jsonResources.EgACLV6Filter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.EgACLV6Filter.Count, strings.ToLower(jsonResources.EgACLV6Filter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.Host0Entry.Max, strings.ToLower(jsonResources.Host0Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.Host0Entry.Count, strings.ToLower(jsonResources.Host0Entry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.HostV4Entry.Max, strings.ToLower(jsonResources.HostV4Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.HostV4Entry.Count, strings.ToLower(jsonResources.HostV4Entry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.HostV6Entry.Max, strings.ToLower(jsonResources.HostV6Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.HostV6Entry.Count, strings.ToLower(jsonResources.HostV6Entry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACL8021XFilter.Max, strings.ToLower(jsonResources.InACL8021XFilter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACL8021XFilter.Count, strings.ToLower(jsonResources.InACL8021XFilter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLCounter.Max, strings.ToLower(jsonResources.InACLCounter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLCounter.Count, strings.ToLower(jsonResources.InACLCounter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLEntry.Max, strings.ToLower(jsonResources.InACLEntry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLEntry.Count, strings.ToLower(jsonResources.InACLEntry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLMeter.Max, strings.ToLower(jsonResources.InACLMeter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLMeter.Count, strings.ToLower(jsonResources.InACLMeter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLMirrorFilter.Max, strings.ToLower(jsonResources.InACLMirrorFilter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLMirrorFilter.Count, strings.ToLower(jsonResources.InACLMirrorFilter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLSlice.Max, strings.ToLower(jsonResources.InACLSlice.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLSlice.Count, strings.ToLower(jsonResources.InACLSlice.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLV4MacFilter.Max, strings.ToLower(jsonResources.InACLV4MacFilter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLV4MacFilter.Count, strings.ToLower(jsonResources.InACLV4MacFilter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLV4MacMangle.Max, strings.ToLower(jsonResources.InACLV4MacMangle.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLV4MacMangle.Count, strings.ToLower(jsonResources.InACLV4MacMangle.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLV6Filter.Max, strings.ToLower(jsonResources.InACLV6Filter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLV6Filter.Count, strings.ToLower(jsonResources.InACLV6Filter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InACLV6Mangle.Max, strings.ToLower(jsonResources.InACLV6Mangle.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InACLV6Mangle.Count, strings.ToLower(jsonResources.InACLV6Mangle.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InPbrV4MacFilter.Max, strings.ToLower(jsonResources.InPbrV4MacFilter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InPbrV4MacFilter.Count, strings.ToLower(jsonResources.InPbrV4MacFilter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.InPbrV6Filter.Max, strings.ToLower(jsonResources.InPbrV6Filter.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.InPbrV6Filter.Count, strings.ToLower(jsonResources.InPbrV6Filter.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.MacEntry.Max, strings.ToLower(jsonResources.MacEntry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.MacEntry.Count, strings.ToLower(jsonResources.MacEntry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.MrouteTotalEntry.Max, strings.ToLower(jsonResources.MrouteTotalEntry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.MrouteTotalEntry.Count, strings.ToLower(jsonResources.MrouteTotalEntry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.Route0Entry.Max, strings.ToLower(jsonResources.Route0Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.Route0Entry.Count, strings.ToLower(jsonResources.Route0Entry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.Route1Entry.Max, strings.ToLower(jsonResources.Route1Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.Route1Entry.Count, strings.ToLower(jsonResources.Route1Entry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.RouteTotalEntry.Max, strings.ToLower(jsonResources.RouteTotalEntry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.RouteTotalEntry.Count, strings.ToLower(jsonResources.RouteTotalEntry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.RouteV4Entry.Max, strings.ToLower(jsonResources.RouteV4Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.RouteV4Entry.Count, strings.ToLower(jsonResources.RouteV4Entry.Name))
-
-	newGauge(ch, resourceDesc["max"], jsonResources.RouteV6Entry.Max, strings.ToLower(jsonResources.RouteV6Entry.Name))
-	newGauge(ch, resourceDesc["used"], jsonResources.RouteV6Entry.Count, strings.ToLower(jsonResources.RouteV6Entry.Name))
+	for k, v := range dataMap {
+		fmt.Println(k,v)
+	        newGauge(ch, resourceDesc["max"], v.Max, strings.ToLower(v.Name))
+	        newGauge(ch, resourceDesc["used"], v.Max, strings.ToLower(v.Name))
+	}
 
 	return nil
 }
 
-type resourceData struct {
-	ACLL4PortRangeCheckers resourceEntry `json:"acl_l4_port_range_checkers"`
-	ECMPNhEntry            resourceEntry `json:"ecmp_nh_entry"`
-	EgACLCounter           resourceEntry `json:"eg_acl_counter"`
-	EgACLEntry             resourceEntry `json:"eg_acl_entry"`
-	EgACLMeter             resourceEntry `json:"eg_acl_meter"`
-	EgACLSlice             resourceEntry `json:"eg_acl_slice"`
-	EgACLV4MacFilter       resourceEntry `json:"eg_acl_v4mac_filter"`
-	EgACLV6Filter          resourceEntry `json:"eg_acl_v6_filter"`
-	Host0Entry             resourceEntry `json:"host_0_entry"`
-	HostV4Entry            resourceEntry `json:"host_v4_entry"`
-	HostV6Entry            resourceEntry `json:"host_v6_entry"`
-	InACL8021XFilter       resourceEntry `json:"in_acl_8021x_filter"`
-	InACLCounter           resourceEntry `json:"in_acl_counter"`
-	InACLEntry             resourceEntry `json:"in_acl_entry"`
-	InACLMeter             resourceEntry `json:"in_acl_meter"`
-	InACLMirrorFilter      resourceEntry `json:"in_acl_mirror_filter"`
-	InACLSlice             resourceEntry `json:"in_acl_slice"`
-	InACLV4MacFilter       resourceEntry `json:"in_acl_v4mac_filter"`
-	InACLV4MacMangle       resourceEntry `json:"in_acl_v4mac_mangle"`
-	InACLV6Filter          resourceEntry `json:"in_acl_v6_filter"`
-	InACLV6Mangle          resourceEntry `json:"in_acl_v6_mangle"`
-	InPbrV4MacFilter       resourceEntry `json:"in_pbr_v4mac_filter"`
-	InPbrV6Filter          resourceEntry `json:"in_pbr_v6_filter"`
-	MacEntry               resourceEntry `json:"mac_entry"`
-	MrouteTotalEntry       resourceEntry `json:"mroute_total_entry"`
-	Route0Entry            resourceEntry `json:"route_0_entry"`
-	Route1Entry            resourceEntry `json:"route_1_entry"`
-	RouteTotalEntry        resourceEntry `json:"route_total_entry"`
-	RouteV4Entry           resourceEntry `json:"route_v4_entry"`
-	RouteV6Entry           resourceEntry `json:"route_v6_entry"`
-}
 
 type resourceEntry struct {
 	Count float64 `json:"count"`

--- a/collector/resource.go
+++ b/collector/resource.go
@@ -68,8 +68,7 @@ func processResourceStats(ch chan<- prometheus.Metric, jsonResourceSum []byte) e
 		return fmt.Errorf("cannot unmarshal resource json: %s", err)
 	}
 
-	for k, v := range dataMap {
-		fmt.Println(k,v)
+	for _, v := range dataMap {
 	        newGauge(ch, resourceDesc["max"], v.Max, strings.ToLower(v.Name))
 	        newGauge(ch, resourceDesc["used"], v.Max, strings.ToLower(v.Name))
 	}


### PR DESCRIPTION
## summary

The JSON key of `cl-resource-query -j` has changed a lot in Cumulus Linux 4.3(mlx). (This is not in the Cumulus documentation, now.)
So it mismatch with `resourceData struct`, and it pasrsed to `cumulus_resource_maximum{resource=""} 0`.

CL 4.3(bcm) may also be different from what it used to be.
It's hard to keep up with these changes in the struct, so I changed it to read JSON keys dynamically in this PR.
This is compatible with the previous.


## details

Error in CL4.3(mlx)

```
$ net show system | grep -Ei "(build|manu)"
Build............ Cumulus Linux 4.3.0
Manufacturer..... Mellanox


$ curl http://127.0.0.1:9365/metrics
# HELP cumulus_collector_up Whether the collector's last scrape was successful (1 = successful, 0 = unsuccessful).
# TYPE cumulus_collector_up gauge
cumulus_collector_up{collector="resource"} 1
cumulus_collector_up{collector="sensor"} 1
# HELP cumulus_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which cumulus_exporter was built.
# TYPE cumulus_exporter_build_info gauge
cumulus_exporter_build_info{branch="HEAD",goversion="go1.13.15",revision="529c81e3cbcdad1ce6c315d8eb2ace5312d7e35b",version="0.1.1"} 1
# HELP cumulus_resource_maximum Resource Maximum.
# TYPE cumulus_resource_maximum gauge
cumulus_resource_maximum{resource=""} 0
cumulus_resource_maximum{resource="egress acl entries"} 0

...<snip>


#
# logs of cumulus_exporter
#
time="2021-02-16T17:19:10+09:00" level=error msg="error gathering metrics: 24 error(s) occurred:\n* [from Gatherer #2] collected metric \"cumulus_resource_maximum\" { label:<name:\"resource\" value:\"\" > gauge:<value:0 > } was collected before with the same name and label values\n* [from Gatherer #2]
...<snip>
collected metric \"cumulus_resource_used\" { label:<name:\"resource\" value:\"\" > gauge:<value:0 > } was collected before with the same name and label values\n" source="log.go:172"
```

"cl-resource-query -j" in CL 4.3(mlx)

```
$ net show system | grep -Ei "(build|manu)"
Build............ Cumulus Linux 4.3.0
Manufacturer..... Mellanox

$ cl-resource-query -j
{
    "acl_mlx_18b_rules_key": {
        "allocated": 0,
        "count": 1,
        "max": 57482,
        "name": "ACL 18B Rules Key",
        "percentage": 0
    },
    "acl_mlx_36b_rules_key": {
        "allocated": 0,
        "count": 0,
        "max": 57481,
        "name": "ACL 36B Rules Key",
        "percentage": 0
    },
    "acl_mlx_54b_rules_key": {
        "allocated": 0,
        "count": 0,
        "max": 34488,
        "name": "ACL 54B Rules Key",
        "percentage": 0
    },
    "acl_mlx_regions": {
        "allocated": 0,
        "count": 4,
        "max": 400,
        "name": "ACL Regions",
        "percentage": 1
    },
    "config_dnat_count": {
        "allocated": 0,
        "count": 0,
        "max": 64,
        "name": "Dynamic Config DNAT entries",
        "percentage": 0
    },
    "config_snat_count": {
        "allocated": 0,
        "count": 0,
        "max": 64,
        "name": "Dynamic Config SNAT entries",
        "percentage": 0
    },
    "dynamic_dnat_count": {
        "allocated": 0,
        "count": 0,
        "max": 1024,
        "name": "Dynamic DNAT entries",
        "percentage": 0
    },
    "dynamic_snat_count": {
        "allocated": 0,
        "count": 0,
        "max": 1024,
        "name": "Dynamic SNAT entries",
        "percentage": 0
    },
    "ecmp_entry": {
        "allocated": 0,
        "count": 0,
        "max": 8571,
        "name": "ECMP entries",
        "percentage": 0
    },
    "ecmp_nh_entry": {
        "allocated": 0,
        "count": 0,
        "max": 33087,
        "name": "Unicast Adjacency entries",
        "percentage": 0
    },
    "eg_acl_entry": {
        "allocated": 0,
        "count": 0,
        "max": 0,
        "name": "Egress ACL entries",
        "percentage": 0
    },
    "eg_acl_mac_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Egress ACL mac filter table"
    },
    "eg_acl_v4_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Egress ACL ipv4 filter table"
    },
    "eg_acl_v6_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Egress ACL ipv6 filter table"
    },
    "host_0_entry": {
        "allocated": 0,
        "count": 0,
        "max": 41360,
        "name": "IPv4 host entries",
        "percentage": 0
    },
    "host_1_entry": {
        "allocated": 0,
        "count": 0,
        "max": 20680,
        "name": "IPv6 host entries",
        "percentage": 0
    },
    "host_v4_entry": {
        "allocated": 0,
        "count": 0,
        "max": 0,
        "name": "IPv4 neighbors",
        "percentage": 0
    },
    "host_v6_entry": {
        "allocated": 0,
        "count": 0,
        "max": 0,
        "name": "IPv6 neighbors",
        "percentage": 0
    },
    "in_acl_entry": {
        "allocated": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress ACL entries",
        "percentage": 0
    },
    "in_acl_mac_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress ACL mac filter table"
    },
    "in_acl_v4_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress ACL ipv4 filter table"
    },
    "in_acl_v4_mangle": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress ACL ipv4 mangle table"
    },
    "in_acl_v6_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress ACL ipv6 filter table"
    },
    "in_acl_v6_mangle": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress ACL ipv6 mangle table"
    },
    "in_pbr_v4_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress PBR ipv4 filter table"
    },
    "in_pbr_v6_filter": {
        "18B": 0,
        "36B": 0,
        "54B": 0,
        "count": 0,
        "max": 0,
        "name": "Ingress PBR ipv6 filter table"
    },
    "mac_entry": {
        "allocated": 0,
        "count": 32,
        "max": 57903,
        "name": "MAC entries",
        "percentage": 0
    },
    "mlx_flow_counters": {
        "allocated": 0,
        "count": 2,
        "max": 39520,
        "name": "Flow Counters",
        "percentage": 0
    },
    "mlx_rif_counters_basic": {
        "allocated": 0,
        "count": 0,
        "max": 7903,
        "name": "RIF Basic Counters",
        "percentage": 0
    },
    "mlx_rif_counters_enh": {
        "allocated": 0,
        "count": 32,
        "max": 2666,
        "name": "RIF Enhanced Counters",
        "percentage": 1
    },
    "mroute_total_entry": {
        "allocated": 0,
        "count": 0,
        "max": 1000,
        "name": "Total Mcast Routes",
        "percentage": 0
    },
    "route_0_entry": {
        "allocated": 0,
        "count": 0,
        "max": 82720,
        "name": "IPv4 route entries",
        "percentage": 0
    },
    "route_1_entry": {
        "allocated": 0,
        "count": 4,
        "max": 74446,
        "name": "IPv6 route entries",
        "percentage": 0
    },
    "route_total_entry": {
        "allocated": 0,
        "count": 4,
        "max": 157166,
        "name": "Total Routes",
        "percentage": 0
    },
    "route_v4_entry": {
        "allocated": 0,
        "count": 0,
        "max": 0,
        "name": "IPv4 Routes",
        "percentage": 0
    },
    "route_v6_entry": {
        "allocated": 0,
        "count": 2,
        "max": 0,
        "name": "IPv6 Routes",
        "percentage": 0
    }
}
```

tested PR in CL 4.3(mlx)

```
$ net show system | grep -Ei "(build|manu)"
Build............ Cumulus Linux 4.3.0
Manufacturer..... Mellanox

$ curl http://127.0.0.1:9365/metrics
# HELP cumulus_collector_up Whether the collector's last scrape was successful (1 = successful, 0 = unsuccessful).
# TYPE cumulus_collector_up gauge
cumulus_collector_up{collector="resource"} 1
cumulus_collector_up{collector="sensor"} 1
cumulus_collector_up{collector="version"} 1
# HELP cumulus_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which cumulus_exporter was built.
# TYPE cumulus_exporter_build_info gauge
cumulus_exporter_build_info{branch="",goversion="go1.15.6",revision="",version=""} 1
# HELP cumulus_resource_maximum Resource Maximum.
# TYPE cumulus_resource_maximum gauge
cumulus_resource_maximum{resource="acl 18b rules key"} 57482
cumulus_resource_maximum{resource="acl 36b rules key"} 57481
cumulus_resource_maximum{resource="acl 54b rules key"} 34488
cumulus_resource_maximum{resource="acl regions"} 400
cumulus_resource_maximum{resource="dynamic config dnat entries"} 64
cumulus_resource_maximum{resource="dynamic config snat entries"} 64
cumulus_resource_maximum{resource="dynamic dnat entries"} 1024
cumulus_resource_maximum{resource="dynamic snat entries"} 1024
cumulus_resource_maximum{resource="ecmp entries"} 8571
cumulus_resource_maximum{resource="egress acl entries"} 0
cumulus_resource_maximum{resource="egress acl ipv4 filter table"} 0
cumulus_resource_maximum{resource="egress acl ipv6 filter table"} 0
cumulus_resource_maximum{resource="egress acl mac filter table"} 0
cumulus_resource_maximum{resource="flow counters"} 39520
cumulus_resource_maximum{resource="ingress acl entries"} 0
cumulus_resource_maximum{resource="ingress acl ipv4 filter table"} 0
cumulus_resource_maximum{resource="ingress acl ipv4 mangle table"} 0
cumulus_resource_maximum{resource="ingress acl ipv6 filter table"} 0
cumulus_resource_maximum{resource="ingress acl ipv6 mangle table"} 0
cumulus_resource_maximum{resource="ingress acl mac filter table"} 0
cumulus_resource_maximum{resource="ingress pbr ipv4 filter table"} 0
cumulus_resource_maximum{resource="ingress pbr ipv6 filter table"} 0
cumulus_resource_maximum{resource="ipv4 host entries"} 41360
cumulus_resource_maximum{resource="ipv4 neighbors"} 0
cumulus_resource_maximum{resource="ipv4 route entries"} 82720
cumulus_resource_maximum{resource="ipv4 routes"} 0
cumulus_resource_maximum{resource="ipv6 host entries"} 20680
cumulus_resource_maximum{resource="ipv6 neighbors"} 0
cumulus_resource_maximum{resource="ipv6 route entries"} 74446
cumulus_resource_maximum{resource="ipv6 routes"} 0
cumulus_resource_maximum{resource="mac entries"} 57903
cumulus_resource_maximum{resource="rif basic counters"} 7903
cumulus_resource_maximum{resource="rif enhanced counters"} 2666
cumulus_resource_maximum{resource="total mcast routes"} 1000
cumulus_resource_maximum{resource="total routes"} 157166
cumulus_resource_maximum{resource="unicast adjacency entries"} 33087
# HELP cumulus_resource_used Resource Used.
# TYPE cumulus_resource_used gauge
cumulus_resource_used{resource="acl 18b rules key"} 1
cumulus_resource_used{resource="acl 36b rules key"} 0
cumulus_resource_used{resource="acl 54b rules key"} 0
cumulus_resource_used{resource="acl regions"} 4
cumulus_resource_used{resource="dynamic config dnat entries"} 0
cumulus_resource_used{resource="dynamic config snat entries"} 0
cumulus_resource_used{resource="dynamic dnat entries"} 0
cumulus_resource_used{resource="dynamic snat entries"} 0
cumulus_resource_used{resource="ecmp entries"} 0
cumulus_resource_used{resource="egress acl entries"} 0
cumulus_resource_used{resource="egress acl ipv4 filter table"} 0
cumulus_resource_used{resource="egress acl ipv6 filter table"} 0
cumulus_resource_used{resource="egress acl mac filter table"} 0
cumulus_resource_used{resource="flow counters"} 2
cumulus_resource_used{resource="ingress acl entries"} 0
...<snip>
```
