### PR TITLE
Return metrics when sensor state is high

### DIFF
--- a/collector/sensor.go
+++ b/collector/sensor.go
@@ -75,7 +75,7 @@ func processSensorStats(ch chan<- prometheus.Metric, jsonSensorSum []byte) error
 	for _, sensor := range jsonSensors {
 		labels := []string{strings.ToLower(sensor.Name), strings.ToLower(sensor.Description)}
 
-		if strings.ToLower(sensor.State) == "ok" {
+		if st := strings.ToLower(sensor.State); st == "ok" || st == "high" {
 			newGauge(ch, sensorDesc["state"], 1.0, labels...)
 
 			if sensor.Type == "fan" {


### PR DESCRIPTION
We faced an issue with the exporter not returning metrics when the sensor state goes to a high state.
I believe it should return metrics as it is very important at that state.

Tested it manually, this fixes the issue we faced.

@tynany 